### PR TITLE
feat(types): adds types for manual type construction

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,73 @@
 // TDDO: use the one from Kea directly
-import { BreakPointFunction, Logic, LogicPropSelectors, SelectorDefinition } from 'kea'
+import { BreakPointFunction, BuiltLogic, Logic, LogicPropSelectors, SelectorDefinition, MakeLogicType } from 'kea'
+
+export type MakeFormLogicType<
+  TForms extends Record<string, Record<string, unknown>> = Record<string, Record<string, unknown>>,
+  TValues extends Record<string, unknown> = Record<string, unknown>,
+  TActions = Record<string, AnyFunction>,
+  TProps = Record<string, unknown>,
+> = MakeLogicType<TValues & FormValues<TForms>, TActions & FormActions<TForms>, TProps>
+
+export type FormValues<
+  TFormData extends Record<string, Record<string, unknown>> = Record<string, Record<string, unknown>>,
+> = {
+  [K in keyof TFormData]: K extends string ? SingleFormValues<K, TFormData[K]> : never
+}
+
+type SingleFormValues<
+  TFormName extends string,
+  TFormData extends Pick<FormInput<Logic>, 'defaults'> = Pick<FormInput<Logic>, 'defaults'>,
+> = ObjectEntries<InterpolatedFormValueTuples<TFormName, TFormData>>
+
+type InterpolatedFormValueTuples<
+  TFormName extends string,
+  TFormData extends Pick<FormInput<Logic>, 'defaults'> = Pick<FormInput<Logic>, 'defaults'>,
+> = [
+  [TFormName, TFormData],
+  [`${TFormName}Changes`, DeepPartial<TFormData>],
+  [`${TFormName}Touches`, DeepPartialMap<TFormData, boolean>],
+  [`is${PascalCase<TFormName>}Submitting`, boolean],
+  [`show${PascalCase<TFormName>}Errors`, boolean],
+  [`${TFormName}Changed`, boolean],
+  [`${TFormName}Touched`, boolean],
+  [`${TFormName}ValidationErrors`, DeepPartialMap<TFormData, ValidationErrorType>],
+  [`${TFormName}HasErrors`, boolean],
+  [`${TFormName}Errors`, DeepPartialMap<TFormData, ValidationErrorType>],
+  [`is${PascalCase<TFormName>}Valid`, boolean],
+]
+
+export type FormActions<
+  TFormData extends Record<string, Record<string, unknown>> = Record<string, Record<string, unknown>>,
+> = {
+  [K in keyof TFormData]: K extends string ? SingleFormActions<K, TFormData[K]> : never
+}
+
+type SingleFormActions<
+  TFormName extends string,
+  TFormData extends Pick<FormInput<Logic>, 'defaults'> = Pick<FormInput<Logic>, 'defaults'>,
+> = ObjectEntries<InterpolatedFormValueTuples<TFormName, TFormData>>
+
+type InterpolatedFormActionTuples<
+  TFormName extends string,
+  TFormData extends Pick<FormInput<Logic>, 'defaults'> = Pick<FormInput<Logic>, 'defaults'>,
+> = [
+  [`set${PascalCase<TFormName>}Value`, (key: keyof TFormData, value: any) => void],
+  [`set${PascalCase<TFormName>}Values`, (values: Partial<TFormData>) => void],
+  [`touch${PascalCase<TFormName>}Field`, (key: keyof TFormData) => void],
+  [`reset${PascalCase<TFormName>}`, (values?: TFormData) => void],
+  [`submit${PascalCase<TFormName>}`, () => void],
+  [`submit${PascalCase<TFormName>}Request`, (formData: TFormData) => void],
+  [`submit${PascalCase<TFormName>}Success`, (formData: TFormData) => void],
+  [`submit${PascalCase<TFormName>}Failure`, (error: Error) => void],
+]
+
+export type AnyFunction = (...args: any) => any
+
+type ObjectEntries<T extends [string, ...unknown[]][]> = { [K in T[number] as K[0]]: K[1] }
+
+type PascalCase<T extends string> = T extends `${infer FirstChar}${infer Rest}`
+  ? `${Capitalize<FirstChar>}${Rest}`
+  : never
 
 export interface FormOptions {
   showErrorsOnTouch: boolean
@@ -17,9 +85,11 @@ export interface FormInput<L extends Logic, T extends Record<string, any> = Reco
 }
 
 export type FormDefinitions<L extends Logic> = L['values'] extends Record<string, any>
-  ? Partial<{
-      [K in keyof L['values']]: FormInput<L, L['values'][K]>
-    }>
+  ? Partial<
+      {
+        [K in keyof L['values']]: FormInput<L, L['values'][K]>
+      }
+    >
   : Record<string, FormInput<L>>
 
 export type FieldNameType = string | number


### PR DESCRIPTION
This PR adds the basic convenience types for manual type construction of logics using `kea-forms`.  There are two primary ways of doing this - directly using `FormValues` and `FormActions` types or using the convenience `MakeFormLogicType` wrapper that pushes the former two utilities into `kea`'s `MakeLogicType`.

In order to get around the TypeScript restrictions on template literal and generic types as keys, I had to create an array of tuples to interpolate and a type utility parallel to `Object.entries` to turn the interpolation into an array using mapped types.  I _believe_ that this is pretty computationally heavy from the typescript side, so I'd especially like feedback on how to improve that if you can think of a meaningful way to do it.

I'll update documentation after I get feedback on the direction of this PR.

Closes #4