### PR TITLE
Add touch errors for nested fields

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -11,7 +11,7 @@ import {
   selectors,
   listeners,
 } from 'kea'
-import { capitalizeFirstLetter, deepAssign, deepTruthy, hasErrors } from './utils'
+import { capitalizeFirstLetter, deepAssign, deepTruthy, hasErrors, getTouchErrors } from './utils'
 
 export function forms<L extends Logic = Logic>(
   input: FormDefinitions<L> | ((logic: BuiltLogic<L>) => FormDefinitions<L>),
@@ -128,11 +128,7 @@ export function forms<L extends Logic = Logic>(
         [`${formKey}Errors`]: [
           (s) => [s[`${formKey}AllErrors`], s[`show${capitalizedFormKey}Errors`], s[`${formKey}Touches`]],
           (allErrors: Record<string, any>, showErrors: boolean, touches: Record<string, boolean>) =>
-            alwaysShowErrors || showErrors
-              ? allErrors
-              : showErrorsOnTouch
-              ? Object.fromEntries(Object.entries(allErrors).filter(([key]) => touches[key]))
-              : {},
+            alwaysShowErrors || showErrors ? allErrors : showErrorsOnTouch ? getTouchErrors(allErrors, touches) : {},
         ],
         [`is${capitalizedFormKey}Valid`]: [
           (s) => [s[`${formKey}ValidationErrors`]],

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -69,3 +69,36 @@ export function splitPathKey(key: FieldName): FieldNamePath {
   }
   return `${key}`.split('.')
 }
+
+export function getTouchErrors(errors: Record<string, any>, touches: Record<string, boolean>) {
+  const target = {}
+
+  for (const [pathStr, _] of Object.entries(touches)) {
+    const path = pathStr.split('.')
+
+    let pathIndex = 0
+    let sourcePointer = errors
+    let targetPointer: any = target
+
+    while (pathIndex < path.length) {
+      let pathElem = path[pathIndex]
+
+      if (!targetPointer.hasOwnProperty(pathElem)) {
+        // End of path, copy the remainder (may be an object like { key: 'Error message' })
+        if (pathIndex === path.length - 1) {
+          targetPointer[pathElem] = JSON.parse(JSON.stringify(sourcePointer[pathElem]))
+        } else if (Array.isArray(sourcePointer[pathElem])) {
+          targetPointer[pathElem] = []
+        } else {
+          targetPointer[pathElem] = {}
+        }
+      }
+
+      targetPointer = targetPointer[pathElem]
+      sourcePointer = sourcePointer[pathElem]
+      pathIndex++
+    }
+  }
+
+  return target
+}


### PR DESCRIPTION
Make _errors on touch_ work on nested fields by selectively copying the errors object.

**Before:**
![2024-03-07 10 37 08](https://github.com/keajs/kea-forms/assets/22996112/b52f89a9-6e43-45bd-bb3c-88d1b1430a59)

**After:**
![2024-03-07 10 34 46](https://github.com/keajs/kea-forms/assets/22996112/3ccfc837-230a-4e79-b46b-60251845851a)